### PR TITLE
Hide EVCS layer legend and use SMK 1.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,14 @@
             "name": "smk-clean-bc",
             "version": "0.0.1",
             "dependencies": {
-                "@bcgov/smk": "1.1.8",
+                "@bcgov/smk": "1.1.9",
                 "http-server": "^14.1.1"
             }
         },
         "node_modules/@bcgov/smk": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.1.8.tgz",
-            "integrity": "sha512-AoVB/FDUKuuJOWPIej728QvRyPHQJzii0mg2UDm+Ht5208Go3qO7QwodVy5mPeCkwFIawIwlAAeCAjXWbre6gw=="
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.1.9.tgz",
+            "integrity": "sha512-rK125+kOO+vy3UfDMCtQgJlHqGyUPCbVpbngiRMl8VS+YArwliveiqcUc78Y7qMl4TaYsriblhjMNmWGKESH4A=="
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -407,9 +407,9 @@
     },
     "dependencies": {
         "@bcgov/smk": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.1.8.tgz",
-            "integrity": "sha512-AoVB/FDUKuuJOWPIej728QvRyPHQJzii0mg2UDm+Ht5208Go3qO7QwodVy5mPeCkwFIawIwlAAeCAjXWbre6gw=="
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.1.9.tgz",
+            "integrity": "sha512-rK125+kOO+vy3UfDMCtQgJlHqGyUPCbVpbngiRMl8VS+YArwliveiqcUc78Y7qMl4TaYsriblhjMNmWGKESH4A=="
         },
         "ansi-styles": {
             "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A Simple Map Kit web application to assist Clean BC with routing to electric vehicle charging stations.",
     "author": "DataBC Map Team",
     "dependencies": {
-        "@bcgov/smk": "1.1.8",
+        "@bcgov/smk": "1.1.9",
         "http-server": "^14.1.1"
     },
     "scripts": {

--- a/smk-config.json
+++ b/smk-config.json
@@ -89,7 +89,8 @@
             "useClustering": false,
             "dataUrl": "./layers/evcs-stalls.geojson",
             "legend": {
-                "point": true
+                "point": true,
+                "excludeOtherLegendWithDefaultStyling": true
             },
             "style": {
                 "strokeColor": "#0000ff",


### PR DESCRIPTION
This updates package.json to consume SMK 1.1.9. It also uses the new 'excludeOtherLegendWithDefaultStyling' vector layer configuration to hide the new 'Other' legend used with conditional styling.